### PR TITLE
Update gemspec to allow activerecord 8.x

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4 if s.respond_to? :specification_version
   s.add_runtime_dependency(%q<rake>, '>= 10.4', '< 14.0')
-  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 8.0'])
+  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 9.0'])
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ctran/annotate_models/issues/",


### PR DESCRIPTION
Temporary patch

https://github.com/ctran/annotate_models/pull/1033